### PR TITLE
Remove usage of private SSH key in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,19 +15,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.21.6-alpine3.18 AS builder
-
-ARG SSH_PRIVATE_KEY
-
-# Prepare SSH mode for downloading git repositories/dependencies
-RUN mkdir /root/.ssh/
-RUN echo "${SSH_PRIVATE_KEY}" > /root/.ssh/id_rsa
-RUN chmod 600 /root/.ssh/id_rsa
-RUN echo "StrictHostKeyChecking no" >> /root/.ssh/config
-
-# Force git to use SSH over HTTPS to avoid password prompt
-RUN apk add git openssh
-RUN git config --global --add url."git@github.com:".insteadOf "https://github.com/"
+FROM golang:1.22-alpine3.18 AS builder
 
 RUN mkdir -p /root/go/src/github.com/awi-infra-guard
 


### PR DESCRIPTION
Previously, the repository required private SSH key for Dockerfile in order to pull private dependencies to build the binary.

Since the dependencies were published, the private SSH key is not needed and the Dockerfile can be used by anyone.