### PR TITLE
Add Dockerfile repository label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ FROM alpine:3.18.4
 WORKDIR /root/
 COPY --from=builder /root/go/src/github.com/awi-infra-guard/awi-infra-guard .
 
+LABEL org.opencontainers.image.source https://github.com/app-net-interface/awi-infra-guard
+
 # As k8s mounting makes it hard to create a file from a config map
 # within the directory with already present files, we create a symlink
 # to point to a new empty directory where actual config.yaml will be


### PR DESCRIPTION
To automatically associate image with a repository in ghcr.io a label was added to a dockerfile.